### PR TITLE
Removed webpack bin path from package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "example": "webpack --config webpack.config.example.js",
     "watch": "webpack --watch"
   },
-  "bin": {
-    "webpack": "node_modules/webpack/bin/webpack"
-  },
   "homepage": "http://unclecheese.github.io/react-selectable",
   "keywords": [
     "selectable",


### PR DESCRIPTION
It had leads build to crash when the project installs as dependency. (atleast on node 0.12)
Actualy npm should resolve webpack binaries by himself.
