### PR TITLE
Disable _mouseDown handler for target in react-dnd

### DIFF
--- a/src/selectable-group.js
+++ b/src/selectable-group.js
@@ -89,6 +89,9 @@ class SelectableGroup extends React.Component {
 	 * be added, and if so, attach event listeners
 	 */
 	_mouseDown (e) {
+		// Disable if target is control by react-dnd
+		if (!!e.target.draggable) return;
+
 		const node = ReactDOM.findDOMNode(this);
 		let collides, offsetData, distanceData;		
 		ReactDOM.findDOMNode(this).addEventListener('mouseup', this._mouseUp);


### PR DESCRIPTION
This allow to use react-dnd with react-selectable.
It ignore the elements that will be handle by react-dnd.
