### PR TITLE
Added the mousemove event when selectOnMouseMove

### DIFF
--- a/dist/react-selectable.js
+++ b/dist/react-selectable.js
@@ -203,7 +203,7 @@ return /******/ (function(modules) { // webpackBootstrap
 					boxTop: Math.min(e.pageY, this._mouseDownData.initialH)
 				});
 
-				if (this.props.selectOnMouseMove) this._throttledSelect();
+				if (this.props.selectOnMouseMove) this._throttledSelect(e);
 			}
 
 			/**

--- a/src/selectable-group.js
+++ b/src/selectable-group.js
@@ -80,7 +80,7 @@ class SelectableGroup extends React.Component {
 	    	boxTop: Math.min(e.pageY, this._mouseDownData.initialH)
 	    });
 
-		if (this.props.selectOnMouseMove) this._throttledSelect();
+		if (this.props.selectOnMouseMove) this._throttledSelect(e);
 	}
 
 


### PR DESCRIPTION
In #21, when selectOnMouseMove, the event object is undefined. This PR solves that, so there will be mousemove events, except the last mouseup event.
