### PR TITLE
Add support for finishing the selection outside the selectable area

### DIFF
--- a/dist/react-selectable.js
+++ b/dist/react-selectable.js
@@ -84,6 +84,8 @@ return /******/ (function(modules) { // webpackBootstrap
 		value: true
 	});
 
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 	var _react = __webpack_require__(2);
@@ -133,6 +135,7 @@ return /******/ (function(modules) { // webpackBootstrap
 			};
 
 			_this._mouseDownData = null;
+			_this._rect = null;
 			_this._registry = [];
 
 			_this._openSelector = _this._openSelector.bind(_this);
@@ -141,7 +144,6 @@ return /******/ (function(modules) { // webpackBootstrap
 			_this._selectElements = _this._selectElements.bind(_this);
 			_this._registerSelectable = _this._registerSelectable.bind(_this);
 			_this._unregisterSelectable = _this._unregisterSelectable.bind(_this);
-
 			_this._throttledSelect = (0, _lodash2.default)(_this._selectElements, 50);
 			return _this;
 		}
@@ -159,7 +161,8 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: 'componentDidMount',
 			value: function componentDidMount() {
-				_reactDom2.default.findDOMNode(this).addEventListener('mousedown', this._mouseDown);
+				document.addEventListener('mousedown', this._mouseDown);
+				this._rect = this._getInitialCoordinates();
 			}
 
 			/**
@@ -169,7 +172,20 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: 'componentWillUnmount',
 			value: function componentWillUnmount() {
-				_reactDom2.default.findDOMNode(this).removeEventListener('mousedown', this._mouseDown);
+				document.removeEventListener('mousedown', this._mouseDown);
+			}
+		}, {
+			key: '_getInitialCoordinates',
+			value: function _getInitialCoordinates() {
+				var style = window.getComputedStyle(document.body);
+				var t = style.getPropertyValue('margin-top');
+				var l = style.getPropertyValue('margin-left');
+				var mLeft = parseInt(l.slice(0, l.length - 2), 10);
+				var mTop = parseInt(t.slice(0, t.length - 2), 10);
+
+				var bodyRect = document.body.getBoundingClientRect();
+				var elemRect = _reactDom2.default.findDOMNode(this).getBoundingClientRect();
+				return { x: Math.round(elemRect.left - bodyRect.left + mLeft), y: Math.round(elemRect.top - bodyRect.top + mTop) };
 			}
 		}, {
 			key: '_registerSelectable',
@@ -192,15 +208,14 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: '_openSelector',
 			value: function _openSelector(e) {
-				var w = Math.abs(this._mouseDownData.initialW - e.pageX);
-				var h = Math.abs(this._mouseDownData.initialH - e.pageY);
-
+				var w = Math.abs(this._mouseDownData.initialW - e.pageX + this._rect.x);
+				var h = Math.abs(this._mouseDownData.initialH - e.pageY + this._rect.y);
 				this.setState({
 					isBoxSelecting: true,
 					boxWidth: w,
 					boxHeight: h,
-					boxLeft: Math.min(e.pageX, this._mouseDownData.initialW),
-					boxTop: Math.min(e.pageY, this._mouseDownData.initialH)
+					boxLeft: Math.min(e.pageX - this._rect.x, this._mouseDownData.initialW),
+					boxTop: Math.min(e.pageY - this._rect.y, this._mouseDownData.initialH)
 				});
 
 				if (this.props.selectOnMouseMove) this._throttledSelect(e);
@@ -221,7 +236,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				var collides = void 0,
 				    offsetData = void 0,
 				    distanceData = void 0;
-				_reactDom2.default.findDOMNode(this).addEventListener('mouseup', this._mouseUp);
+				document.addEventListener('mouseup', this._mouseUp);
 
 				// Right clicks
 				if (e.which === 3 || e.button === 2) return;
@@ -234,24 +249,24 @@ return /******/ (function(modules) { // webpackBootstrap
 						bottom: offsetData.offsetHeight,
 						right: offsetData.offsetWidth
 					}, {
-						top: e.pageY,
-						left: e.pageX,
+						top: e.pageY - this._rect.y,
+						left: e.pageX - this._rect.x,
 						offsetWidth: 0,
 						offsetHeight: 0
 					});
 					if (!collides) return;
 				}
-
+				this._rect = this._getInitialCoordinates();
 				this._mouseDownData = {
-					boxLeft: e.pageX,
-					boxTop: e.pageY,
-					initialW: e.pageX,
-					initialH: e.pageY
+					boxLeft: e.pageX - this._rect.x,
+					boxTop: e.pageY - this._rect.y,
+					initialW: e.pageX - this._rect.x,
+					initialH: e.pageY - this._rect.y
 				};
 
 				if (this.props.preventDefault) e.preventDefault();
 
-				_reactDom2.default.findDOMNode(this).addEventListener('mousemove', this._openSelector);
+				document.addEventListener('mousemove', this._openSelector);
 			}
 
 			/**
@@ -261,9 +276,10 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: '_mouseUp',
 			value: function _mouseUp(e) {
-				_reactDom2.default.findDOMNode(this).removeEventListener('mousemove', this._openSelector);
-				_reactDom2.default.findDOMNode(this).removeEventListener('mouseup', this._mouseUp);
-
+				e.stopPropagation();
+				document.removeEventListener('mousemove', this._openSelector);
+				document.removeEventListener('mouseup', this._mouseUp);
+				// debugger;
 				if (!this._mouseDownData) return;
 
 				this._selectElements(e);
@@ -283,9 +299,9 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: '_selectElements',
 			value: function _selectElements(e) {
-				var currentItems = [];
-				var selectbox = _reactDom2.default.findDOMNode(this.refs.selectbox);
-				var tolerance = this.props.tolerance;
+				var currentItems = [],
+				    selectbox = _reactDom2.default.findDOMNode(this.refs.selectbox),
+				    tolerance = this.props.tolerance;
 
 
 				if (!selectbox) return;
@@ -307,6 +323,10 @@ return /******/ (function(modules) { // webpackBootstrap
 		}, {
 			key: 'render',
 			value: function render() {
+				var wrapperStyle = {
+					position: 'relative',
+					overflow: 'visible'
+				};
 
 				var boxStyle = {
 					left: this.state.boxLeft,
@@ -336,7 +356,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 				return _react2.default.createElement(
 					this.props.component,
-					filteredProps,
+					_extends({}, filteredProps, { style: wrapperStyle }),
 					this.state.isBoxSelecting && _react2.default.createElement(
 						'div',
 						{ style: boxStyle, ref: 'selectbox' },
@@ -532,7 +552,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
 
-	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 	/**
 	 * lodash (Custom Build) <https://lodash.com/>

--- a/example/App.js
+++ b/example/App.js
@@ -34,12 +34,12 @@ class App extends React.Component {
 
 
 	componentDidMount () {
-		document.addEventListener('click', this.clearItems);
+		document.addEventListener('mousedown', this.clearItems);
 	}
 
 
 	componentWillUnmount () {
-		document.removeEventListener('click', this.clearItems);
+		document.removeEventListener('mousedown', this.clearItems);
 	}
 
 
@@ -76,7 +76,7 @@ class App extends React.Component {
 			<div>
 				<h1>React Selectable Demo</h1>
 				<div className="sidebar">
-					<div className="info">						
+					<div className="info">
 						<strong>Tolerance</strong>: <span>{this.state.tolerance}</span><br/>
 						<em>The number of pixels that must be in the bounding box in order for an item to be selected.</em>
 						<p><input type="range" min="0" max="50" step="1" onChange={this.handleToleranceChange} value={this.state.tolerance} /></p>
@@ -100,27 +100,27 @@ class App extends React.Component {
 					</div>
 				</div>
 				<SelectableGroup
-					className="main" 
+					className="main"
 					ref="selectable"
-					onSelection={this.handleSelection} 
+					onSelection={this.handleSelection}
 					tolerance={this.state.tolerance}
 					selectOnMouseMove={this.state.selectOnMouseMove}>
-				
+
 				{this.props.items.map((item, i) => {
 					const selected = this.state.selectedItems.indexOf(i) > -1;
 					return (
 						<SelectableAlbum
 							selectableKey={i}
-							key={i} 
-							title={item.title} 
-							year={item.year} 
+							key={i}
+							title={item.title}
+							year={item.year}
 							selected={selected} />
 					);
 				})}
 				</SelectableGroup>
 			</div>
 
-		);		
+		);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
     "lodash.throttle": "^4.0.1",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "webpack": "^1.12.11"
   }
 }

--- a/src/selectable-group.js
+++ b/src/selectable-group.js
@@ -18,6 +18,7 @@ class SelectableGroup extends React.Component {
 		}
 
 		this._mouseDownData = null;
+		this._rect = null;
 		this._registry = [];
 
 		this._openSelector = this._openSelector.bind(this);
@@ -26,7 +27,6 @@ class SelectableGroup extends React.Component {
 		this._selectElements = this._selectElements.bind(this);
 		this._registerSelectable = this._registerSelectable.bind(this);
 		this._unregisterSelectable = this._unregisterSelectable.bind(this);
-
 		this._throttledSelect = throttle(this._selectElements, 50);
 	}
 
@@ -42,17 +42,28 @@ class SelectableGroup extends React.Component {
 
 
 	componentDidMount () {
-		ReactDOM.findDOMNode(this).addEventListener('mousedown', this._mouseDown);
+		document.addEventListener('mousedown', this._mouseDown);
+		this._rect = this._getInitialCoordinates();
 	}
-
 
 	/**
 	 * Remove global event listeners
 	 */
 	componentWillUnmount () {
-		ReactDOM.findDOMNode(this).removeEventListener('mousedown', this._mouseDown);
+		document.removeEventListener('mousedown', this._mouseDown);
 	}
 
+	_getInitialCoordinates() {
+	    const style = window.getComputedStyle(document.body);
+		const t = style.getPropertyValue('margin-top');
+	    const l = style.getPropertyValue('margin-left');
+		const mLeft = parseInt(l.slice(0, l.length - 2), 10);
+		const mTop = parseInt(t.slice(0, t.length - 2), 10);
+
+		const bodyRect = document.body.getBoundingClientRect();
+	    const elemRect = ReactDOM.findDOMNode(this).getBoundingClientRect();
+		return { x: Math.round(elemRect.left - bodyRect.left + mLeft) , y: Math.round(elemRect.top - bodyRect.top + mTop) }
+	}
 
 	_registerSelectable (key, domNode) {
 		this._registry.push({key, domNode});
@@ -69,15 +80,14 @@ class SelectableGroup extends React.Component {
 	 * of the selection box
 	 */
 	_openSelector (e) {
-	    const w = Math.abs(this._mouseDownData.initialW - e.pageX);
-	    const h = Math.abs(this._mouseDownData.initialH - e.pageY);
-
+	    const w = Math.abs(this._mouseDownData.initialW - e.pageX + this._rect.x);
+	    const h = Math.abs(this._mouseDownData.initialH - e.pageY + this._rect.y);
 	    this.setState({
 	    	isBoxSelecting: true,
 	    	boxWidth: w,
 	    	boxHeight: h,
-	    	boxLeft: Math.min(e.pageX, this._mouseDownData.initialW),
-	    	boxTop: Math.min(e.pageY, this._mouseDownData.initialH)
+	    	boxLeft: Math.min(e.pageX - this._rect.x, this._mouseDownData.initialW),
+	    	boxTop: Math.min(e.pageY - this._rect.y, this._mouseDownData.initialH)
 	    });
 
 		if (this.props.selectOnMouseMove) this._throttledSelect(e);
@@ -94,7 +104,7 @@ class SelectableGroup extends React.Component {
 
 		const node = ReactDOM.findDOMNode(this);
 		let collides, offsetData, distanceData;
-		ReactDOM.findDOMNode(this).addEventListener('mouseup', this._mouseUp);
+		document.addEventListener('mouseup', this._mouseUp);
 
 		// Right clicks
 		if(e.which === 3 || e.button === 2) return;
@@ -109,25 +119,25 @@ class SelectableGroup extends React.Component {
 					right: offsetData.offsetWidth
 				},
 				{
-					top: e.pageY,
-					left: e.pageX,
+					top: e.pageY - this._rect.y,
+					left: e.pageX - this._rect.x,
 					offsetWidth: 0,
 					offsetHeight: 0
 				}
 			);
 			if(!collides) return;
 		}
-
+		this._rect = this._getInitialCoordinates();
 		this._mouseDownData = {
-			boxLeft: e.pageX,
-			boxTop: e.pageY,
-	        initialW: e.pageX,
-        	initialH: e.pageY
+			boxLeft: e.pageX - this._rect.x,
+			boxTop: e.pageY - this._rect.y,
+	        initialW: e.pageX - this._rect.x,
+        	initialH: e.pageY - this._rect.y
 		};
 
 		if(this.props.preventDefault) e.preventDefault();
 
-		ReactDOM.findDOMNode(this).addEventListener('mousemove', this._openSelector);
+		document.addEventListener('mousemove', this._openSelector);
 	}
 
 
@@ -135,9 +145,10 @@ class SelectableGroup extends React.Component {
 	 * Called when the user has completed selection
 	 */
 	_mouseUp (e) {
-	    ReactDOM.findDOMNode(this).removeEventListener('mousemove', this._openSelector);
-	    ReactDOM.findDOMNode(this).removeEventListener('mouseup', this._mouseUp);
-
+		e.stopPropagation();
+	    document.removeEventListener('mousemove', this._openSelector);
+	    document.removeEventListener('mouseup', this._mouseUp);
+		// debugger;
 	    if(!this._mouseDownData) return;
 
 		this._selectElements(e);
@@ -176,6 +187,10 @@ class SelectableGroup extends React.Component {
 	 * @return {ReactComponent}
 	 */
 	render () {
+		const wrapperStyle = {
+			position: 'relative',
+			overflow: 'visible'
+		};
 
 		const boxStyle = {
 			left: this.state.boxLeft,
@@ -204,7 +219,7 @@ class SelectableGroup extends React.Component {
         delete filteredProps.preventDefault;
 
         return (
-            <this.props.component {...filteredProps}>
+            <this.props.component {...filteredProps} style={wrapperStyle}>
                 {this.state.isBoxSelecting &&
                   <div style={boxStyle} ref="selectbox"><span style={spanStyle}></span></div>
                 }


### PR DESCRIPTION
When you selecting items and you finish out of the selectable area you enter in a stuck state.
Adding listeners to the document will help on this

Example
![react-selectable](https://cloud.githubusercontent.com/assets/2563196/21568744/dfdef662-ceae-11e6-937a-68dfab107c34.gif)

The PR include also a change that set the container to be in position relative, and will calculate the rect are from the beginning of this area instead of from the beginning of the page.

Before if you include the `SelectableGroup` in a container with position relative or absolute with top or left different than 0 it won't work as expected anymore.