### PR TITLE
Disable the selectable box if target parent is control by react-dnd

### DIFF
--- a/src/selectable-group.js
+++ b/src/selectable-group.js
@@ -90,7 +90,7 @@ class SelectableGroup extends React.Component {
 	 */
 	_mouseDown (e) {
 		// Disable if target is control by react-dnd
-		if (!!e.target.draggable) return;
+		if (!!e.target.draggable || !!e.target.parentElement.draggable) return;
 
 		const node = ReactDOM.findDOMNode(this);
 		let collides, offsetData, distanceData;


### PR DESCRIPTION
Disable if the target **parent** is draggable besides the target itself:

`if (!!e.target.draggable || !!e.target.parentElement.draggable) return;`

When I have an element inside the draggable div and mouseDown event is triggered, the selectable box appears and it should not.

In my case, I am using with react-grid-layout that have the resizable functionality inside the div.